### PR TITLE
Add option to use file for host info

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,9 +32,10 @@ func main() {
 	app.Version = Version
 	app.Flags = []cli.Flag{
 		&cli.StringSliceFlag{
-			Name:    "host, H",
-			Usage:   "Server host",
-			EnvVars: []string{"PLUGIN_HOST", "SCP_HOST", "SSH_HOST", "HOST", "INPUT_HOST"},
+			Name:     "host, H",
+			Usage:    "Server host",
+			EnvVars:  []string{"PLUGIN_HOST", "SCP_HOST", "SSH_HOST", "HOST", "INPUT_HOST"},
+			FilePath: ".host",
 		},
 		&cli.StringFlag{
 			Name:    "port, P",


### PR DESCRIPTION
Add option to use file for host info. In my drone pipeline I create VMs that I don't know the IP before hand, so I need some way of passing host info to drone-scp plugin.